### PR TITLE
Add support for history end_time param & make time parameter optional

### DIFF
--- a/lib/History.js
+++ b/lib/History.js
@@ -10,25 +10,25 @@ class History extends Request {
 
   // GET /api/history/period/<timestamp>
   // https://home-assistant.io/developers/rest_api/#get-apihistoryperiodlttimestamp
-  state(timestamp, filter, endTimestamp) {
-    if (timestamp !== undefined && moment(timestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
-      return Promise.reject(new Error('Invalid timestamp format.'));
+  state(startTimestamp, filter, endTimestamp) {
+    if (startTimestamp !== undefined && moment(startTimestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
+      return Promise.reject(new Error('Invalid startTimestamp format.'));
     }
     if (endTimestamp !== undefined && moment(endTimestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
-      return Promise.reject(new Error('Invalid timestamp for endTimestamp format.'));
+      return Promise.reject(new Error('Invalid endTimestamp format.'));
     }
 
     const qs = {};
 
     if (filter !== undefined) {
-      cs.filter_entity_id = filter;
+      qs.filter_entity_id = filter;
     }
 
     if (endTimestamp !== undefined) {
-      cs.end_time = endTimestamp;
+      qs.end_time = endTimestamp;
     }
 
-    return this._get(`/history/period/${timestamp || ""}`, qs);
+    return this._get(`/history/period/${startTimestamp || ""}`, qs);
   }
 }
 

--- a/lib/History.js
+++ b/lib/History.js
@@ -28,7 +28,7 @@ class History extends Request {
       qs.end_time = endTimestamp;
     }
 
-    return this._get(`/history/period/${startTimestamp || ""}`, qs);
+    return this._get(`/history/period/${startTimestamp || ''}`, qs);
   }
 }
 

--- a/lib/History.js
+++ b/lib/History.js
@@ -10,13 +10,25 @@ class History extends Request {
 
   // GET /api/history/period/<timestamp>
   // https://home-assistant.io/developers/rest_api/#get-apihistoryperiodlttimestamp
-  state(timestamp, filter) {
-    if (moment(timestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
+  state(timestamp, filter, endTimestamp) {
+    if (timestamp !== undefined && moment(timestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
       return Promise.reject(new Error('Invalid timestamp format.'));
     }
+    if (endTimestamp !== undefined && moment(endTimestamp, 'YYYY-MM-DDTHH:mm:ssZ', true).isValid() === false) {
+      return Promise.reject(new Error('Invalid timestamp for endTimestamp format.'));
+    }
 
-    const qs = filter ? { filter_entity_id: filter } : null;
-    return this._get(`/history/period/${timestamp}`, qs);
+    const qs = {};
+
+    if (filter !== undefined) {
+      cs.filter_entity_id = filter;
+    }
+
+    if (endTimestamp !== undefined) {
+      cs.end_time = endTimestamp;
+    }
+
+    return this._get(`/history/period/${timestamp || ""}`, qs);
   }
 }
 


### PR DESCRIPTION
As documented in the [REST API](https://developers.home-assistant.io/docs/en/external_api_rest.html) HA docs, there's another parameter `end_time` which is not covered by the API.

Furthermore, the `timestamp` field was made optional as this is also supported according to the HA docs.

I'd appreciate any feedback and am looking forward to getting this into the next version of this npm module.
Thanks!